### PR TITLE
Add a missing parameter to error factory method

### DIFF
--- a/infra/inmemory/users.go
+++ b/infra/inmemory/users.go
@@ -58,7 +58,7 @@ var (
 )
 
 func errUserNotFound(userID uint64) *chat.NotFoundError {
-	return chat.NewNotFoundError("user (id=%v) is not found")
+	return chat.NewNotFoundError("user (id=%v) is not found", userID)
 }
 
 var userCounter uint64 = uint64(len(userMap))


### PR DESCRIPTION
`chat.NewNotFoundError`の変換指定子に対応する引数がなかったので追加しました。