### PR TITLE
Fix missing user_id in message responses

### DIFF
--- a/chat/queried/queried.go
+++ b/chat/queried/queried.go
@@ -63,7 +63,7 @@ type RoomMessages struct {
 
 type Message struct {
 	MessageID uint64    `json:"message_id"`
-	UserID    uint64 `json:"user_id"`
+	UserID    uint64    `json:"user_id"`
 	Content   string    `json:"content"`
 	CreatedAt time.Time `json:"created_at"`
 }

--- a/chat/queried/queried.go
+++ b/chat/queried/queried.go
@@ -63,6 +63,7 @@ type RoomMessages struct {
 
 type Message struct {
 	MessageID uint64    `json:"message_id"`
+	UserID    uint64 `json:"user_id"`
 	Content   string    `json:"content"`
 	CreatedAt time.Time `json:"created_at"`
 }

--- a/chat/query_service.go
+++ b/chat/query_service.go
@@ -113,7 +113,7 @@ func (s *QueryService) FindRoomMessages(ctx context.Context, userID uint64, q ac
 	for _, m := range msgs {
 		qm := queried.Message{
 			MessageID: m.ID,
-            UserID:    m.UserID,
+			UserID:    m.UserID,
 			Content:   m.Content,
 			CreatedAt: m.CreatedAt,
 		}

--- a/chat/query_service.go
+++ b/chat/query_service.go
@@ -113,6 +113,7 @@ func (s *QueryService) FindRoomMessages(ctx context.Context, userID uint64, q ac
 	for _, m := range msgs {
 		qm := queried.Message{
 			MessageID: m.ID,
+            UserID:    m.UserID,
 			Content:   m.Content,
 			CreatedAt: m.CreatedAt,
 		}

--- a/infra/inmemory/messages.go
+++ b/infra/inmemory/messages.go
@@ -159,7 +159,7 @@ func (repo *MessageRepository) FindUnreadRoomMessages(ctx context.Context, userI
 		if m, ok := messageMap[id]; ok {
 			qm := queried.Message{
 				MessageID: m.ID,
-                UserID:    m.UserID,
+				UserID:    m.UserID,
 				Content:   m.Content,
 				CreatedAt: m.CreatedAt,
 			}

--- a/infra/inmemory/messages.go
+++ b/infra/inmemory/messages.go
@@ -159,6 +159,7 @@ func (repo *MessageRepository) FindUnreadRoomMessages(ctx context.Context, userI
 		if m, ok := messageMap[id]; ok {
 			qm := queried.Message{
 				MessageID: m.ID,
+                UserID:    m.UserID,
 				Content:   m.Content,
 				CreatedAt: m.CreatedAt,
 			}


### PR DESCRIPTION
#`/chat/rooms/2/messages`と`/chat/rooms/2/messages/unread` のレスポンスの各メッセージに`user_id`を入れるようにしました。