### PR TITLE
Hotfix/missing notification for delete room

### DIFF
--- a/chat/hub.go
+++ b/chat/hub.go
@@ -174,18 +174,10 @@ func (hub *HubImpl) sendEvent(ctx context.Context, ev event.Event) error {
 		targetIDs = room.MemberIDSet.List()
 
 	case event.RoomCreated:
-		room, err := chatCommand.rooms.Find(ctx, ev.RoomID)
-		if err != nil {
-			return err
-		}
-		targetIDs = room.MemberIDSet.List()
+		targetIDs = ev.MemberIDs
 
 	case event.RoomDeleted:
-		room, err := chatCommand.rooms.Find(ctx, ev.RoomID)
-		if err != nil {
-			return err
-		}
-		targetIDs = room.MemberIDSet.List()
+		targetIDs = ev.MemberIDs
 
 	case event.RoomAddedMember:
 		room, err := chatCommand.rooms.Find(ctx, ev.RoomID)

--- a/chat/hub_test.go
+++ b/chat/hub_test.go
@@ -77,11 +77,11 @@ func TestHubSendEvent(t *testing.T) {
 			SendUserIDs: RoomMemberIDs,
 		},
 		{
-			Event:       event.RoomCreated{RoomID: RoomID},
+			Event:       event.RoomCreated{RoomID: RoomID, MemberIDs: RoomMemberIDs},
 			SendUserIDs: RoomMemberIDs,
 		},
 		{
-			Event:       event.RoomDeleted{RoomID: RoomID},
+			Event:       event.RoomDeleted{RoomID: RoomID, MemberIDs: RoomMemberIDs},
 			SendUserIDs: RoomMemberIDs,
 		},
 		{
@@ -161,16 +161,10 @@ func TestHubSendEventFail(t *testing.T) {
 		Event       event.Event
 		SendUserIDs []uint64
 	}{
+		// These events access to the repositories and gots error.
+		// The other events, not accessing to the repositories, are not shown.
 		{
 			Event:       event.MessageCreated{RoomID: RoomID},
-			SendUserIDs: RoomMemberIDs,
-		},
-		{
-			Event:       event.RoomCreated{RoomID: RoomID},
-			SendUserIDs: RoomMemberIDs,
-		},
-		{
-			Event:       event.RoomDeleted{RoomID: RoomID},
 			SendUserIDs: RoomMemberIDs,
 		},
 		{

--- a/rest.go
+++ b/rest.go
@@ -107,7 +107,7 @@ func (rest *RESTHandler) DeleteRoom(e echo.Context) error {
 		RoomID: deletedID,
 		OK:     true,
 	}
-	return e.JSON(http.StatusNoContent, response)
+	return e.JSON(http.StatusOK, response)
 }
 
 func (rest *RESTHandler) AddRoomMember(e echo.Context) error {

--- a/rest_test.go
+++ b/rest_test.go
@@ -212,7 +212,7 @@ func TestRESTDeleteRoom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expect, got := http.StatusNoContent, rec.Code; expect != got {
+	if expect, got := http.StatusOK, rec.Code; expect != got {
 		t.Errorf("different http status code, expect: %v, got: %v", expect, got)
 	}
 


### PR DESCRIPTION
Fix missing notification for DeleteRoom event.

* uses MessageIDs in event RoomCreated and RoomDeleted for notifying targets.