### PR TITLE
Hotfix/#20 use query parameter for query actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,18 +221,24 @@ response JSON:
 }
 ```
 
-### GetUnreadRoomMessage -- `GET /chat/rooms/:room_id/messages/unread`
+### GetRoomMessage -- `GET /chat/rooms/:room_id/messages`
 
-It returns messages unread by the logged-in user in the room specified by `room_id`.
+It returns messages in the room specified by `room_id`.
+The returned messages contains both read and unread messages.
+
+Query Paramters:
+
+* `before`: The start point of the `created_at` in result messages. It must be RFC3339 form.
+* `limit`: The number of result messages.
 
 Request JSON: 
 
 ```javascript
 {
+    "before": "time with RFC3339 format",
     "limit": limit_number,
 }
 ```
-
 
 response JSON:
 
@@ -252,6 +258,52 @@ response JSON:
     "messages_size": messages_size,
 }
 ```
+
+Example:
+
+`GET /chat/rooms/:room_id/messages?before=2018-01-01T12:34:56Z?limit=10` will returns 
+queried result which contains 10 messages and all of these are created before 2018/01/01 12:34:56.
+
+
+### GetUnreadRoomMessage -- `GET /chat/rooms/:room_id/messages/unread`
+
+It returns messages unread by the logged-in user in the room specified by `room_id`.
+
+Query Paramters:
+
+* `limit`: The number of result messages.
+
+Request JSON: 
+
+```javascript
+{
+    "limit": limit_number,
+}
+```
+
+response JSON:
+
+```javascript
+{
+    "room_id": room_id,
+
+    "messages": [
+        {
+            "message_id": message_id,
+            "content":    "<message content>",
+            "created_at": created_at,
+        },
+        ...
+    ],
+
+    "messages_size": messages_size,
+}
+```
+
+Example:
+
+`GET /chat/rooms/:room_id/messages/unread?limit=10` will returns queried result which contains 10 messages.
+
 
 ### ReadRoomMessages -- `POST /chat/rooms/:room_id/messages/read`
 

--- a/chat/action/query.go
+++ b/chat/action/query.go
@@ -1,18 +1,16 @@
 package action
 
-import "time"
-
 // QueryRoomMessages is a query for
 // messages in specified room.
 type QueryRoomMessages struct {
-	RoomID uint64    `json:"room_id"`
-	Before time.Time `json:"before"`
-	Limit  int       `json:"limit"`
+	RoomID uint64
+	Before Timestamp `json:"before" query:"before"`
+	Limit  int       `json:"limit" query:"limit"`
 }
 
 // QueryUnreadRoomMessages is a query for
 // unread messages by user in specified room.
 type QueryUnreadRoomMessages struct {
-	RoomID uint64 `json:"room_id"`
-	Limit  int    `json:"limit"`
+	RoomID uint64
+	Limit  int `json:"limit" query:"limit"`
 }

--- a/chat/action/timestamp.go
+++ b/chat/action/timestamp.go
@@ -1,0 +1,40 @@
+package action
+
+import "time"
+
+// SupportedTimeFormat is time representation format to be acceptable for the application.
+// all of the time representation format should be in manner of this format.
+const SupportedTimeFormat = time.RFC3339
+
+// Timestamp is Time data which implements some custom encoders and decoders.
+type Timestamp time.Time
+
+// TimestampNow is shorthand for Timestamp(time.Now()).
+func TimestampNow() Timestamp {
+	return Timestamp(time.Now())
+}
+
+// implements json.Marshaler interface.
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	return t.Time().MarshalJSON() // The format of default marshaler is RFC3339.
+}
+
+// implements json.Unmarshaler interface.
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	var ts = time.Time{}
+	err := ts.UnmarshalJSON(data)
+	*t = Timestamp(ts)
+	return err
+}
+
+// implements github.com/labstack/echo.BindUnmarshaler interface.
+func (t *Timestamp) UnmarshalParam(src string) error {
+	ts, err := time.Parse(SupportedTimeFormat, src)
+	*t = Timestamp(ts)
+	return err
+}
+
+// Time returns its internal representation as time.Time.
+func (t *Timestamp) Time() time.Time {
+	return time.Time(*t)
+}

--- a/chat/action/timestamp.go
+++ b/chat/action/timestamp.go
@@ -19,6 +19,11 @@ func (t Timestamp) MarshalJSON() ([]byte, error) {
 	return t.Time().MarshalJSON() // The format of default marshaler is RFC3339.
 }
 
+// implements json.TextMarshaler interface.
+func (t Timestamp) MarshalText() ([]byte, error) {
+	return t.Time().MarshalText() // The format of default marshaler is RFC3339.
+}
+
 // implements json.Unmarshaler interface.
 func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	var ts = time.Time{}
@@ -35,6 +40,6 @@ func (t *Timestamp) UnmarshalParam(src string) error {
 }
 
 // Time returns its internal representation as time.Time.
-func (t *Timestamp) Time() time.Time {
-	return time.Time(*t)
+func (t Timestamp) Time() time.Time {
+	return time.Time(t)
 }

--- a/chat/action/timestamp_test.go
+++ b/chat/action/timestamp_test.go
@@ -1,0 +1,50 @@
+package action
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTimestampMarshalJSON(t *testing.T) {
+	var tm = TimestampNow()
+	bs, err := json.Marshal(tm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	strip := strings.Trim(string(bs), "\"")
+	parsed, err := time.Parse(SupportedTimeFormat, strip)
+	if err != nil {
+		t.Fatalf("can not parse with SupportedTimeFormat, expect format: %v, got: %v", SupportedTimeFormat, strip)
+	}
+	if !parsed.Equal(tm.Time()) {
+		t.Errorf("different time after parsing from json string")
+	}
+
+	var newTm Timestamp
+	if err := json.Unmarshal(bs, &newTm); err != nil {
+		t.Fatalf("can not Unmarshal: %v", err)
+	}
+	if !newTm.Time().Equal(tm.Time()) {
+		t.Errorf("different time after Unmarshaling from json")
+	}
+}
+
+func TestTimestampUnmarshalText(t *testing.T) {
+	var tm = Timestamp(time.Now())
+	bs, err := json.Marshal(tm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	strip := strings.Trim(string(bs), "\"")
+	var newTm Timestamp
+	if err := newTm.UnmarshalParam(strip); err != nil {
+		t.Fatalf("can not UnmarshalParam: %v", err)
+	}
+	if !newTm.Time().Equal(tm.Time()) {
+		t.Errorf("different time after UnmarshalParam, expect: %v, got: %v", newTm.Time(), tm.Time())
+	}
+}

--- a/chat/action/timestamp_test.go
+++ b/chat/action/timestamp_test.go
@@ -33,18 +33,31 @@ func TestTimestampMarshalJSON(t *testing.T) {
 }
 
 func TestTimestampUnmarshalText(t *testing.T) {
+	var testStrings = make([]string, 0, 2)
 	var tm = Timestamp(time.Now())
+
+	// json text
 	bs, err := json.Marshal(tm)
 	if err != nil {
 		t.Fatal(err)
 	}
+	testStrings = append(testStrings, strings.Trim(string(bs), "\""))
 
-	strip := strings.Trim(string(bs), "\"")
-	var newTm Timestamp
-	if err := newTm.UnmarshalParam(strip); err != nil {
-		t.Fatalf("can not UnmarshalParam: %v", err)
+	// format text
+	bs, err = tm.MarshalText()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !newTm.Time().Equal(tm.Time()) {
-		t.Errorf("different time after UnmarshalParam, expect: %v, got: %v", newTm.Time(), tm.Time())
+	testStrings = append(testStrings, string(bs))
+
+	for _, text := range testStrings {
+		var newTm Timestamp
+		if err := newTm.UnmarshalParam(text); err != nil {
+			t.Fatalf("can not UnmarshalParam: %v", err)
+		}
+		if !newTm.Time().Equal(tm.Time()) {
+			t.Errorf("different time after UnmarshalParam, expect: %v, got: %v", newTm.Time(), tm.Time())
+		}
 	}
+	t.Logf("src text are: %#v", testStrings)
 }

--- a/chat/query_service.go
+++ b/chat/query_service.go
@@ -108,8 +108,8 @@ func (s *QueryServiceImpl) FindRoomMessages(ctx context.Context, userID uint64, 
 		q.Limit = MaxRoomMessagesLimit
 	}
 
-	if q.Before == (time.Time{}) {
-		q.Before = time.Now()
+	if q.Before.Time().Equal(time.Time{}) {
+		q.Before = action.TimestampNow()
 	}
 
 	// TODO create specific queried data, messages associated with room ID and user ID,
@@ -126,7 +126,7 @@ func (s *QueryServiceImpl) FindRoomMessages(ctx context.Context, userID uint64, 
 		return nil, fmt.Errorf("can not get the messages from room(id=%d) by not a room member user(id=%d)", q.RoomID, userID)
 	}
 
-	msgs, err := s.msgs.FindRoomMessagesOrderByLatest(ctx, q.RoomID, q.Before, q.Limit)
+	msgs, err := s.msgs.FindRoomMessagesOrderByLatest(ctx, q.RoomID, q.Before.Time(), q.Limit)
 	if err != nil {
 		if IsNotFoundError(err) {
 			// TODO use logger
@@ -143,11 +143,11 @@ func (s *QueryServiceImpl) FindRoomMessages(ctx context.Context, userID uint64, 
 	roomMsgs := &queried.RoomMessages{
 		RoomID: q.RoomID,
 	}
-	roomMsgs.Cursor.Current = q.Before
+	roomMsgs.Cursor.Current = q.Before.Time()
 	if last := len(msgs) - 1; last >= 0 {
 		roomMsgs.Cursor.Next = msgs[last].CreatedAt
 	} else {
-		roomMsgs.Cursor.Next = q.Before
+		roomMsgs.Cursor.Next = q.Before.Time()
 	}
 
 	qMsgs := make([]queried.Message, 0, len(msgs))

--- a/chat/query_service_test.go
+++ b/chat/query_service_test.go
@@ -98,7 +98,7 @@ func TestQueryServiceFindRoomMessagesSuccess(t *testing.T) {
 
 	queryRMsgs := action.QueryRoomMessages{
 		RoomID: room.ID,
-		Before: time.Now(),
+		Before: action.TimestampNow(),
 		Limit:  10,
 	}
 
@@ -118,7 +118,7 @@ func TestQueryServiceFindRoomMessagesSuccess(t *testing.T) {
 		{
 			ID:        1,
 			Content:   "hello",
-			CreatedAt: queryRMsgs.Before.Add(-100 * time.Millisecond),
+			CreatedAt: queryRMsgs.Before.Time().Add(-100 * time.Millisecond),
 		},
 	}
 	msgQr := mocks.NewMockMessageQueryer(mockCtrl)
@@ -126,7 +126,7 @@ func TestQueryServiceFindRoomMessagesSuccess(t *testing.T) {
 		FindRoomMessagesOrderByLatest(
 			gomock.Any(),
 			room.ID,
-			queryRMsgs.Before,
+			queryRMsgs.Before.Time(),
 			queryRMsgs.Limit,
 		).
 		Return(messages, nil).
@@ -148,10 +148,10 @@ func TestQueryServiceFindRoomMessagesSuccess(t *testing.T) {
 	if msgs.RoomID != queryRMsgs.RoomID {
 		t.Errorf("different room id, expect: %v, got: %v", queryRMsgs.RoomID, msgs.RoomID)
 	}
-	if got, expect := msgs.Cursor.Current, queryRMsgs.Before; expect != got {
+	if got, expect := msgs.Cursor.Current, queryRMsgs.Before.Time(); !expect.Equal(got) {
 		t.Errorf("different current cursor, expect: %v, got: %v", expect, got)
 	}
-	if got, expect := msgs.Cursor.Next, messages[0].CreatedAt; expect != got {
+	if got, expect := msgs.Cursor.Next, messages[0].CreatedAt; !expect.Equal(got) {
 		t.Errorf("different next cursor, expect: %v, got: %v", expect, got)
 	}
 	if got, expect := msgs.Msgs[0].Content, messages[0].Content; expect != got {
@@ -229,7 +229,7 @@ func TestQueryServiceFindRoomMessagesFail(t *testing.T) {
 
 	queryRMsgs := action.QueryRoomMessages{
 		RoomID: room.ID,
-		Before: time.Now(),
+		Before: action.TimestampNow(),
 		Limit:  10,
 	}
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -14,3 +14,12 @@ func NormTimestampNow() action.Timestamp {
 	newNow.UnmarshalParam(string(bs))
 	return newNow
 }
+
+// MustMarshal returns byte slice which ensure
+// the error is nil.
+func MustMarshal(bs []byte, err error) []byte {
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,16 @@
+package chat
+
+import (
+	"github.com/shirasudon/go-chat/chat/action"
+)
+
+// NormTimestampNow returns normalized action.Timestamp.
+// Normalization is performed by dump it with MarshalText() and then
+// re-construct with UnmarshalParam().
+func NormTimestampNow() action.Timestamp {
+	now := action.TimestampNow()
+	bs, _ := now.MarshalText()
+	var newNow action.Timestamp
+	newNow.UnmarshalParam(string(bs))
+	return newNow
+}

--- a/rest_test.go
+++ b/rest_test.go
@@ -931,7 +931,7 @@ func TestRESTGetRoomMessages(t *testing.T) {
 		RESTHandler := &RESTHandler{chatQuery: qs}
 
 		query := action.QueryRoomMessages{
-			Before: time.Now(),
+			Before: action.TimestampNow(),
 			Limit:  1,
 		}
 		req, err := newJSONRequest(echo.GET, "/rooms/:room_id/messages", query)
@@ -991,7 +991,7 @@ func TestRESTGetRoomMessages(t *testing.T) {
 		RESTHandler := &RESTHandler{chatQuery: qs}
 
 		query := action.QueryRoomMessages{
-			Before: time.Now(),
+			Before: action.TimestampNow(),
 			Limit:  1,
 		}
 		req, err := newJSONRequest(echo.GET, "/rooms/:room_id/messages", query)


### PR DESCRIPTION
Using query parameters with URL, `/chat/rooms/:room_id/messages?before=xxx`,  is preferred for query action.
This PR implements that. close #20  