### PR TITLE
infra/inmemory: make Repository should not persist events on Store()

### DIFF
--- a/infra/inmemory/messages.go
+++ b/infra/inmemory/messages.go
@@ -144,6 +144,7 @@ func (repo *MessageRepository) FindRoomMessagesOrderByLatest(ctx context.Context
 
 func (repo *MessageRepository) Store(ctx context.Context, m domain.Message) (uint64, error) {
 	// TODO create or update
+	m.EventHolder = domain.NewEventHolder() // event should not be persisted.
 	messageCounter += 1
 	m.ID = messageCounter
 	m.CreatedAt = time.Now()

--- a/infra/inmemory/messages_test.go
+++ b/infra/inmemory/messages_test.go
@@ -65,6 +65,9 @@ func TestMessageRepoStore(t *testing.T) {
 	if stored.Content != Content {
 		t.Errorf("different message content in the datastore, expect: %v, got: %v", Content, stored.Content)
 	}
+	if len(stored.Events()) != 0 {
+		t.Errorf("event should not be persisted")
+	}
 }
 
 func TestMessageRepoFind(t *testing.T) {

--- a/infra/inmemory/rooms.go
+++ b/infra/inmemory/rooms.go
@@ -67,6 +67,7 @@ func (repo *RoomRepository) FindAllByUserID(ctx context.Context, userID uint64) 
 }
 
 func (repo *RoomRepository) Store(ctx context.Context, r domain.Room) (uint64, error) {
+	r.EventHolder = domain.NewEventHolder() // event should not be persisted.
 	if r.NotExist() {
 		return repo.Create(ctx, r)
 	} else {

--- a/infra/inmemory/users.go
+++ b/infra/inmemory/users.go
@@ -64,6 +64,7 @@ func errUserNotFound(userID uint64) *chat.NotFoundError {
 var userCounter uint64 = uint64(len(userMap))
 
 func (repo UserRepository) Store(ctx context.Context, u domain.User) (uint64, error) {
+	u.EventHolder = domain.NewEventHolder() // event should not be persisted.
 	if u.NotExist() {
 		return repo.Create(ctx, u)
 	} else {

--- a/main/index.html
+++ b/main/index.html
@@ -3,6 +3,7 @@
     <title>websocket sample</title>
     <script type="text/javascript">
     var wsUri = "ws://localhost:8080/chat/ws"; 
+    var chatURL = "http://localhost:8080/chat"; 
 
     var output;  
     function init() { 
@@ -28,7 +29,6 @@
 
     function onOpen(evt) { 
         writeToScreen("CONNECTED"); 
-        doSend("websocketにメッセージを送信"); 
     }  
 
     function onClose(evt) { 
@@ -37,7 +37,7 @@
 
     function onMessage(evt) { 
         var jsonData=JSON.parse(evt.data);
-        writeToScreen('<span style="color: blue;">RESPONSE: ' + jsonData.content + '</span>'); 
+        writeToScreen('<span style="color: blue;">RESPONSE: ' + evt.data + '</span>'); 
     }  
 
     function onError(evt) { 
@@ -48,8 +48,10 @@
         writeToScreen("SENT: " + message);
         var jsonData={
             action:"CHAT_MESSAGE",
-            room_id: 2,
-            content:message,
+            data: {
+              room_id: 2,
+              content:message,
+            }
         };
 
         websocket.send(JSON.stringify(jsonData)); 
@@ -69,6 +71,17 @@
         doSend(inputtext.value);
         inputtext.value = "";
     }
+
+    function onReadButtonClick() {
+      writeToScreen("SENT: READ MESSAGES");
+      var jsonData = {
+        action: "READ_MESSAGE",
+        data: {
+          room_id: 2,
+        }
+      };
+      websocket.send(JSON.stringify(jsonData));
+    };
     </script>
 </head>
 <body>
@@ -80,6 +93,12 @@
         <form>
             <input type="text" id="inputtext"/>
             <input type="button" onclick="onClick();" value="send!" />
+        </form>
+    </div>
+
+    <div id="reader">
+        <form>
+            <input type="button" onclick="onReadButtonClick();" value="read!" />
         </form>
     </div>
 


### PR DESCRIPTION
Currently, [User|Room|Message]Repositories persist also domain events. This introduces that the same events are stored multiple times for the Event store, and are published multiple times.
See #26 for example of the problem. 

This PR fixes that problem by clear the events in the domain models at Repository.Store(). 
